### PR TITLE
Fixed UITableView warning message

### DIFF
--- a/CodeView/MainViewController.swift
+++ b/CodeView/MainViewController.swift
@@ -124,7 +124,7 @@ class MainViewController: UIViewController {
         snapshot.appendSections(Section.allCases)
         snapshot.appendItems(xLayoutList, toSection: .x)
         snapshot.appendItems(yLayoutList, toSection: .y)
-        dataSource.apply(snapshot,animatingDifferences: true)
+        dataSource.apply(snapshot,animatingDifferences: dataSource.snapshot().numberOfSections > 0)
     }
     
     


### PR DESCRIPTION
테이블 뷰가 불러와지지 않은 시점에 애니메이션을 적용하면 안됩니다.